### PR TITLE
Updated the style to target only pseudo element

### DIFF
--- a/az-icons-styles.css
+++ b/az-icons-styles.css
@@ -11,7 +11,7 @@
 }
 
 
-[class^="az-icon-"], [class*=" az-icon-"] {
+[class^="az-icon-"]::before, [class*=" az-icon-"]::before {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: 'az-icons' !important;
   speak: never;


### PR DESCRIPTION
All text wrapped in the class was getting a serif fallback font (bug). Targeting just the pseudo element in the css fixes the issue.